### PR TITLE
Change class attribute to className

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -138,7 +138,7 @@ function App() {
             <button>Update user</button>
             <button
               onClick={() => setEditing(false)}
-              class="button muted-button"
+              className="button muted-button"
             >
               Cancel
             </button>


### PR DESCRIPTION
The Cancel button has a `class` attribute instead of `className`.