### PR TITLE
Disable the delete button when a user is being edited.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -66,7 +66,12 @@ const App = () => {
 				</div>
 				<div className="flex-large">
 					<h2>View users</h2>
-					<UserTable users={users} editRow={editRow} deleteUser={deleteUser} />
+					<UserTable 
+                        editing={editing}
+                        users={users} 
+                        editRow={editRow} 
+                        deleteUser={deleteUser} 
+                    />
 				</div>
 			</div>
 		</div>

--- a/src/tables/UserTable.js
+++ b/src/tables/UserTable.js
@@ -25,6 +25,7 @@ const UserTable = props => (
                 Edit
               </button>
               <button
+                disabled={props.editing}
                 onClick={() => props.deleteUser(user.id)}
                 className="button muted-button"
               >


### PR DESCRIPTION
Hello, I was reading your wonderful article here:
https://www.taniarascia.com/crud-app-in-react-with-hooks/
  
Towards the end of the article, when handling the 'two issues,' I read this line:
"[one] can delete a user while it is currently being edited" to mean that once clicking the edit button, either the update user or cancel button would need to be clicked before deleting the user that was being edited.
 
Unfortunately, I was unable to achieve this behavior with useEffect alone on my local.
I consulted the live demo to confirm my expectations about this functionality and noticed the result was the same, or similar, in the live demo to my results.
That is to say, I can delete a user while editing said user in the live demo.

To remedy this, I simply passed editing as a prop to UserTable and used the value of editing to set the disabled attribute of the button.

I greatly appreciated the demo, and your time, and hope this contribution is helpful for your project.